### PR TITLE
Add ShaderValidator::uniform_name_map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozangle"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["The ANGLE Project Authors", "The Servo Project Developers"]
 license = " BSD-3-Clause"
 description = "Mozilla’s fork of Google ANGLE, repackaged as a Rust crate "

--- a/src/shaders/glslang-c.cpp
+++ b/src/shaders/glslang-c.cpp
@@ -78,3 +78,16 @@ extern "C"
 const char* GLSLangGetObjectCode(const ShHandle handle) {
     return sh::GetObjectCode(handle).c_str();
 }
+
+using StrPairFunction = void (*)(void *, const char *, size_t, const char *, size_t);
+
+extern "C"
+void GLSLangIterUniformNameMapping(const ShHandle handle, StrPairFunction each, void *closure_each) {
+    for (auto& uniform : *sh::GetUniforms(handle)) {
+        each(
+            closure_each,
+            uniform.name.data(), uniform.name.length(),
+            uniform.mappedName.data(), uniform.mappedName.length()
+        );
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -38,6 +38,10 @@ void main() {
                                               &resources).unwrap();
 
     assert!(compiler.compile_and_translate(&[source]).is_ok());
+
+    let map = compiler.uniform_name_map();
+    let keys = map.keys().collect::<Vec<_>>();
+    assert_eq!(keys, &["uSampler"], "name hashing map: {:?}", map)
 }
 
 #[test]


### PR DESCRIPTION
This is to be used by `WebGLRenderingContext.getUniformLocation` in Servo. Background: https://github.com/servo/servo/pull/20216#issuecomment-371310789