### PR TITLE
shaders: Document what happens with uniform_name_map when there's no SH_VARIABLES.

### DIFF
--- a/src/shaders/mod.rs
+++ b/src/shaders/mod.rs
@@ -243,6 +243,10 @@ impl ShaderValidator {
         Ok(self.object_code())
     }
 
+    /// Returns a map from uniform name in the original shader to uniform name
+    /// in the compiled shader.
+    ///
+    /// The map can be empty if the `SH_VARIABLES` option wasn't specified.
     pub fn uniform_name_map(&self) -> HashMap<String, String> {
         struct Closure {
             map: HashMap<String, String>,


### PR DESCRIPTION
This addresses my own review comments in #2.