### PR TITLE
Enable some EGL extensions in bindings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozangle"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["The ANGLE Project Authors", "The Servo Project Developers"]
 license = " BSD-3-Clause"
 description = "Mozilla’s fork of Google ANGLE, repackaged as a Rust crate "

--- a/build.rs
+++ b/build.rs
@@ -89,6 +89,9 @@ fn generate_bindings() {
         "EGL_ANGLE_device_d3d",
         "EGL_EXT_platform_base",
         "EGL_EXT_platform_device",
+        "EGL_KHR_create_context",
+        "EGL_EXT_create_context_robustness",
+        "EGL_KHR_create_context_no_error",
     ])
         .write_bindings(gl_generator::StaticGenerator, &mut file)
         .unwrap();


### PR DESCRIPTION
They are used by Glutin-like usage of EGL