### PR TITLE
Require C++ 11 rather than gnu++ 11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozangle"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["The ANGLE Project Authors", "The Servo Project Developers"]
 license = " BSD-3-Clause"
 description = "Mozilla’s fork of Google ANGLE, repackaged as a Rust crate "

--- a/build.rs
+++ b/build.rs
@@ -51,7 +51,7 @@ fn build_angle() {
         .file("src/shaders/glslang-c.cpp")
         .cpp(true)
         .warnings(false)
-        .flag_if_supported("-std=gnu++11")
+        .flag("-std=c++11")
         .flag_if_supported("-msse2")  // GNU
         .flag_if_supported("-arch:SSE2")  // MSVC
         .compile("angle");


### PR DESCRIPTION
Use the C++ std rather than the gnu std. Makes life easer with clang. Also, complain earlier in the build if the C++ std isn't available.  Part of smup https://github.com/servo/servo/pull/21029