### PR TITLE
Improve libEGL build for Windows arm64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozangle"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["The ANGLE Project Authors", "The Servo Project Developers"]
 license = " BSD-3-Clause"
 description = "Mozilla’s fork of Google ANGLE, repackaged as a Rust crate "

--- a/build.rs
+++ b/build.rs
@@ -27,12 +27,17 @@ fn build_egl(target: &str) {
         build.include(fixup_path(file));
     }
 
+    for file in data.sources {
+        build.file(fixup_path(file));
+    }
+
     if target.contains("x86_64") || target.contains("i686") {
         build
             .flag_if_supported("-msse2")  // GNU
             .flag_if_supported("-arch:SSE2");  // MSVC
     }
 
+    // Build DLL.
     let mut cmd = build.get_compiler().to_command();
     let out = env::var("OUT_DIR").unwrap();
     let out = Path::new(&out);
@@ -54,6 +59,9 @@ fn build_egl(target: &str) {
     cmd.arg("/DEF:gfx/angle/checkout/src/libEGL/libEGL.def");
     let status = cmd.status();
     assert!(status.unwrap().success());
+
+    // Build lib.
+    build.compile("EGL");
 }
 
 fn build_angle() {

--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,12 @@ fn build_egl(target: &str) {
         build.include(fixup_path(file));
     }
 
+    if target.contains("x86_64") || target.contains("i686") {
+        build
+            .flag_if_supported("-msse2")  // GNU
+            .flag_if_supported("-arch:SSE2");  // MSVC
+    }
+
     let mut cmd = build.get_compiler().to_command();
     let out = env::var("OUT_DIR").unwrap();
     let out = Path::new(&out);


### PR DESCRIPTION
This disables the use of SSE2 in libEGL on non-Intel targets, and also generates a static libEGL.lib.