### PR TITLE
Bring back `egl::get_proc_address`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,13 @@ pub mod egl {
     use std::ffi::CString;
     use std::os::raw::c_void;
 
+    pub fn get_proc_address(name: &str) -> *const c_void {
+        let name = CString::new(name.as_bytes()).unwrap();
+        unsafe {
+            ffi::GetProcAddress(name.as_ptr()) as *const _ as _
+        }
+    }
+
     pub mod ffi {
         use std::os::raw::{c_void, c_long};
 


### PR DESCRIPTION
Based on https://github.com/servo/mozangle/commit/b76657d1453ecc7902bd6c62fd5912bc2770e00c#r35009042