### PR TITLE
Force clang to treat all input files as C++.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozangle"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["The ANGLE Project Authors", "The Servo Project Developers"]
 license = " BSD-3-Clause"
 description = "Mozilla’s fork of Google ANGLE, repackaged as a Rust crate "

--- a/build.rs
+++ b/build.rs
@@ -176,6 +176,7 @@ fn build_angle() {
         .file("src/shaders/glslang-c.cpp")
         .cpp(true)
         .warnings(false)
+        .flag_if_supported("-xc++")
         .flag_if_supported("-std=c++14")
         .flag_if_supported("/wd4100")
         .flag_if_supported("/wd4127")


### PR DESCRIPTION
Fixes #38. sccache guesses what mode to run the compiler in based on the filename, which makes clang complain when we pass C++ flags when building C files. Forcing C++ mode causes sccache to skip the heuristic and clang happily compiles.