### PR TITLE
Make an 'uninitialized' variant to avoid panics in 1.48.0

### DIFF
--- a/src/shaders/bindings.rs
+++ b/src/shaders/bindings.rs
@@ -92,6 +92,7 @@ pub const SH_INIT_SHARED_VARIABLES: ShCompileOptions = 2199023255552;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ShArrayIndexClampingStrategy {
+    SH_UNINITIALIZED = 0,
     SH_CLAMP_WITH_CLAMP_INTRINSIC = 1,
     SH_CLAMP_WITH_USER_DEFINED_INT_CLAMP_FUNCTION = 2,
 }


### PR DESCRIPTION
Fixes #43