### PR TITLE
Add function to count number of unpacked varying vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozangle"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["The ANGLE Project Authors", "The Servo Project Developers"]
 license = " BSD-3-Clause"
 description = "Mozilla’s fork of Google ANGLE, repackaged as a Rust crate "

--- a/src/shaders/glslang-c.cpp
+++ b/src/shaders/glslang-c.cpp
@@ -1,4 +1,5 @@
 #include "GLSLANG/ShaderLang.h"
+#include "common/utilities.h"
 
 extern "C"
 int GLSLangInitialize() {
@@ -90,4 +91,25 @@ void GLSLangIterUniformNameMapping(const ShHandle handle, StrPairFunction each, 
             uniform.mappedName.data(), uniform.mappedName.length()
         );
     }
+}
+
+// Returns the number of vectors that the shader's active varyings fit
+// in to without additional packing. Can be used to test whether a
+// shader will compile on drivers that do not perform spec-compliant
+// packing. This contrasts with sh::CheckVariablesWithinPackingLimits
+// which does pack the varyings in accordance with the spec.
+extern "C"
+int GLSLangGetNumUnpackedVaryingVectors(const ShHandle handle) {
+  int total_rows = 0;
+  const std::vector<sh::Varying>* varyings = sh::GetVaryings(handle);
+
+  if (varyings) {
+    for (const auto& varying : *varyings) {
+      if (varying.active) {
+        total_rows += gl::VariableRowCount(varying.type) * varying.getArraySizeProduct();
+      }
+    }
+  }
+
+  return total_rows;
 }

--- a/src/shaders/mod.rs
+++ b/src/shaders/mod.rs
@@ -24,6 +24,7 @@ pub mod ffi {
             each: unsafe extern fn(*mut c_void, *const c_char, usize, *const c_char, usize),
             closure_each: *mut c_void
         );
+        pub fn GLSLangGetNumUnpackedVaryingVectors(handle: ShHandle) -> c_int;
     }
 }
 
@@ -291,6 +292,12 @@ impl ShaderValidator {
             panic!("Non-UTF-8 uniform name in ANGLE shader: {}", err)
         }
         closure.map
+    }
+
+    pub fn get_num_unpacked_varying_vectors(&self) -> i32 {
+        unsafe {
+            GLSLangGetNumUnpackedVaryingVectors(self.handle)
+        }
     }
 }
 


### PR DESCRIPTION
This counts the number of vectors used by each active varying in a
shader. This can be used to ensure that a shader will succesfully
compile without using more than GL_MAX_VARYING_VECTORS on devices that
do not perform spec-compliant packing of varyings. This is in contrast
to sh::CheckVariablesWithinPackingLimits(), which checks whether there
are enough vectors *with* spec-compliant packing.