### PR TITLE
Use default stable rust compiler.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,11 +14,6 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install latest nightly
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.45.0
-        default: true
     - name: Run tests
       run: cargo test --verbose --features "egl build_dlls"
 


### PR DESCRIPTION
CI is currently broken because we're pinned to an old cargo version that doesn't support the 2021 edition.