### PR TITLE
Bump `cc` to 1.0.74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ lazy_static = "1.0"
 dlopen = "0.1"
 
 [build-dependencies]
-cc = { version = "1.0.5", features = ["parallel"] }
+cc = { version = "1.0.74", features = ["parallel"] }
 gl_generator = { version = "0.13.1", optional = true }
 walkdir = "2"
 


### PR DESCRIPTION
I was having some problems compiling servo because Cargo was resolving `cc` to 1.0.73, even though the `build.rs` script from `mozangle` uses `cc::Build::link_lib_modifier` which was introduced in [cc@1.0.74](https://github.com/rust-lang/cc-rs/releases/tag/1.0.74)