### PR TITLE
Remove duplicate source files in generate_build_data.py

### DIFF
--- a/generate_build_data.py
+++ b/generate_build_data.py
@@ -18,6 +18,17 @@ def run():
         directory = path.join(ANGLE, "targets", lib)
         parse_lib(directory, data[lib])
         parse_lib(ANGLE, data[lib], ".common")
+
+    # Remove duplicate source files from libEGL and libGLESv2 since
+    # they are included in libANGLE and will be statically linked in.
+    def remove_duplicates_source_files(from_data: list[str]):
+        from_data['SOURCES'] = [
+            file for file in from_data['SOURCES']
+                if file not in data['libANGLE']['SOURCES']]
+
+    remove_duplicates_source_files(data['libEGL'])
+    remove_duplicates_source_files(data['libGLESv2'])
+
     with open(path.join(REPO, "build_data.rs"), "wb") as f:
         write(data, f)
 


### PR DESCRIPTION
This was done manually in a previous commit, but this change makes sure
that when regenerating the source file, duplicate are not included.
