### PR TITLE
Add Merge Queue support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,8 @@ name: Rust
 on:
   push:
   pull_request:
+  merge_group:
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR adds the 'merge_group' trigger to the workflow currently used for both PR and bors merge checks.

The 'Required Checks' option in 'Settings' will need to be updated to include the two jobs in the workflow.

Note: Enabling merge queue will prevent bors from being able to merge.