### PR TITLE
Weekly run CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   merge_group:
     branches: [master]
+  schedule:
+    # Runs at 04:30, every Saturday
+    - cron: "30 4 * * 6"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
to catch runner/rust changes.

Similar as https://github.com/servo/mozjs/pull/428