### PR TITLE
Update to version 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mozangle"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The ANGLE Project Authors", "The Servo Project Developers"]
 license = "BSD-3-Clause"
 description = "Mozilla's fork of Google ANGLE, repackaged as a Rust crate."


### PR DESCRIPTION
This will allow dependencies to pick up the new version of bindgen.
