### PR TITLE
Improve build time on Windows with clang-cl

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -394,11 +394,12 @@ fn fixup_path(path: &str) -> String {
 fn generate_gl_bindings() {
     println!("generate_gl_bindings");
     use gl_generator::{Api, Fallbacks, Profile, Registry};
-    use std::fs::File;
+    use std::{fs::File, io::Write};
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
     let mut file = File::create(&out_dir.join("egl_bindings.rs")).unwrap();
+    file.write_all(b"#[allow(unused_imports)]\n").unwrap();
     Registry::new(
         Api::Egl,
         (1, 5),
@@ -417,6 +418,7 @@ fn generate_gl_bindings() {
     .unwrap();
 
     let mut file = File::create(&out_dir.join("gles_bindings.rs")).unwrap();
+    file.write_all(b"#[allow(unused_imports)]\n").unwrap();
     Registry::new(Api::Gles2, (2, 0), Profile::Core, Fallbacks::None, [])
         .write_bindings(gl_generator::StaticGenerator, &mut file)
         .unwrap();

--- a/build.rs
+++ b/build.rs
@@ -234,7 +234,8 @@ fn build_lib(compiled_libraries: &mut HashSet<Libs>, target: &String, lib: Libs)
     build
         .flag_if_supported("/wd4100")
         .flag_if_supported("/wd4127")
-        .flag_if_supported("/wd9002");
+        .flag_if_supported("/wd9002")
+        .flag_if_supported("-Wno-unused-command-line-argument");
 
     if target.contains("x86_64") || target.contains("i686") {
         build


### PR DESCRIPTION
To workaround clang-cl not supporting multi-process compile (`/MP` flag) split DLL build in two steps:

1. compile the source files to object files (runs in parallel with parallel feature from cc)
2. link the object files into a DLL