### PR TITLE
Fix cross-compiling with dylib feature

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -323,13 +323,11 @@ fn build_translator(compiled_libraries: &mut HashSet<Libs>, target: &String) {
 
         cmd.arg("src/shaders/glslang-c.cpp");
         println!("cargo:rustc-link-lib=dylib={}", "glslang_glue");
-        #[cfg(target_os = "macos")]
-        {
+        let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("Cargo error?");
+        if target_os == "macos" {
             let file = out_dir.join("libglslang_glue.dylib");
             cmd.arg("-o").arg(&file);
-        }
-        #[cfg(target_os = "linux")]
-        {
+        } else if target_os == "linux" {
             let file = out_dir.join(format!("libglslang_glue.so"));
             cmd.arg("-o").arg(&file);
         }


### PR DESCRIPTION
When cross-compiling the host OS may be different from the target OS. E.g. one may be compiling for Linux on a Windows machine. In build-scripts one needs to reed the
`TARGET` environment variables that cargo sets,
since build scripts themselves are always compiled for the host platform.

I came across this while investigating a different issue.