### PR TITLE
Remove lazy_static dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 
 [dependencies]
 libz-sys = { version = "1.1", optional = true }
-lazy_static = "1.0"
 
 [dev-dependencies]
 dlopen = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
 // This extern crates are needed for linking
 #[cfg(test)]
 extern crate dlopen;

--- a/src/shaders/mod.rs
+++ b/src/shaders/mod.rs
@@ -21,9 +21,7 @@ use std::slice;
 use std::str;
 use std::sync::Mutex;
 
-lazy_static! {
-    static ref CONSTRUCT_COMPILER_LOCK: Mutex<()> = Mutex::new(());
-}
+static CONSTRUCT_COMPILER_LOCK: Mutex<()> = Mutex::new(());
 
 pub fn initialize() -> Result<(), &'static str> {
     if unsafe { GLSLangInitialize() } == 0 {


### PR DESCRIPTION
Mutex can now be constructed in const contexts,
so we don't need to lazily construct it anymore.