### PR TITLE
CI: add workflow_dispatch and use latest clang

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "20.0"
+          version: "20"
       - name: Run tests
         run: cargo test --verbose ${{ matrix.cargo-options }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,9 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.81
-      - name: Set env
-        if: contains(matrix.os, 'ubuntu')
-        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "20.0"
       - name: Run tests
         run: cargo test --verbose ${{ matrix.cargo-options }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.81
       - name: Install LLVM and Clang
+        if: ${{ !contains(matrix.os, 'macos') }}
         uses: KyleMayes/install-llvm-action@v2
         with:
           version: "20"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ on:
   schedule:
     # Runs at 04:30, every Saturday
     - cron: "30 4 * * 6"
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
we need taltes clang because of https://github.com/actions/runner-images/issues/12435