### PR TITLE
ci: Update Rust toolchain version to 1.88

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.81
+      - uses: dtolnay/rust-toolchain@1.88
       - name: Install LLVM and Clang
         if: ${{ !contains(matrix.os, 'macos') }}
         uses: KyleMayes/install-llvm-action@v2

--- a/build.rs
+++ b/build.rs
@@ -257,8 +257,9 @@ fn build_lib(compiled_libraries: &mut HashSet<Libs>, target: &String, lib: Libs)
     // we want all symbols as they are for consumers (are shared libs)
     if data.shared {
         build.link_lib_modifier("-bundle");
-        build.link_lib_modifier("+whole-archive");
     }
+
+    build.link_lib_modifier("+whole-archive");
 
     build.compile(data.lib);
 


### PR DESCRIPTION
To fix CI: https://github.com/servo/mozangle/actions/runs/29141242178/job/86514745581#step:5:62