### PR TITLE
Fix build with single-pass linkers 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.81
+      - uses: dtolnay/rust-toolchain@1.88
       - name: Install LLVM and Clang
         if: ${{ !contains(matrix.os, 'macos') }}
         uses: KyleMayes/install-llvm-action@v2

--- a/build.rs
+++ b/build.rs
@@ -156,28 +156,30 @@ fn build_windows_dll(data: &build_data::Data, dll_name: &str, def_file: &str) {
 }
 
 fn build_lib(compiled_libraries: &mut HashSet<Libs>, target: &String, lib: Libs) {
-    let mut reverse_link_order = vec![];
-    collect_reverse_link_order(&mut reverse_link_order, lib);
-    let link_order = reverse_link_order.iter().rev();
+    let link_order = collect_link_order(lib);
     for lib in link_order {
-        build_single_lib(compiled_libraries, target, *lib);
+        build_single_lib(compiled_libraries, target, lib);
     }
 }
 
-/// Determines the link order (reversed) of libraries
+/// Returns libraries in linker order, i.e. dependents before dependencies.
 ///
-/// This means that for each library, all dependencies will be to the left in `order`.
-/// Traditional linkers which scan from left to right, require that dependencies appear
-/// to the right on the linker line of the library that required a symbol, so that undefined symbols
-/// can be resolved in one scan from left to right over the linked library list.
-/// Since I'm not sure how to construct that, this function returns the reverse order, and it's
-/// up to the caller to use `.rev()` to get the linker order.
-fn collect_reverse_link_order(order: &mut Vec<Libs>, lib: Libs) {
+/// We need to compile in this order, since the order the link statements are
+/// emitted in (by cc-rs) is the order they end up on the linker line.
+fn collect_link_order(lib: Libs) -> Vec<Libs> {
+    let mut dependency_order = vec![];
+    collect_depth_first_order(&mut dependency_order, lib);
+    dependency_order.reverse();
+    dependency_order
+}
+
+/// Collects libraries using depth first search
+fn collect_depth_first_order(order: &mut Vec<Libs>, lib: Libs) {
     if order.contains(&lib) {
         return;
     }
     for dep_lib in lib.to_data().use_libs {
-        collect_reverse_link_order(order, *dep_lib);
+        collect_depth_first_order(order, *dep_lib);
     }
     order.push(lib);
 }

--- a/build.rs
+++ b/build.rs
@@ -156,6 +156,33 @@ fn build_windows_dll(data: &build_data::Data, dll_name: &str, def_file: &str) {
 }
 
 fn build_lib(compiled_libraries: &mut HashSet<Libs>, target: &String, lib: Libs) {
+    let mut reverse_link_order = vec![];
+    collect_reverse_link_order(&mut reverse_link_order, lib);
+    let link_order = reverse_link_order.iter().rev();
+    for lib in link_order {
+        build_single_lib(compiled_libraries, target, *lib);
+    }
+}
+
+/// Determines the link order (reversed) of libraries
+///
+/// This means that for each library, all dependencies will be to the left in `order`.
+/// Traditional linkers which scan from left to right, require that dependencies appear
+/// to the right on the linker line of the library that required a symbol, so that undefined symbols
+/// can be resolved in one scan from left to right over the linked library list.
+/// Since I'm not sure how to construct that, this function returns the reverse order, and it's
+/// up to the caller to use `.rev()` to get the linker order.
+fn collect_reverse_link_order(order: &mut Vec<Libs>, lib: Libs) {
+    if order.contains(&lib) {
+        return;
+    }
+    for dep_lib in lib.to_data().use_libs {
+        collect_reverse_link_order(order, *dep_lib);
+    }
+    order.push(lib);
+}
+
+fn build_single_lib(compiled_libraries: &mut HashSet<Libs>, target: &String, lib: Libs) {
     // Do not rebuild this library if it is already built.
     if compiled_libraries.contains(&lib) {
         return;
@@ -163,9 +190,6 @@ fn build_lib(compiled_libraries: &mut HashSet<Libs>, target: &String, lib: Libs)
 
     println!("build_lib: {lib:?}");
     let data = lib.to_data();
-    for dep_lib in data.use_libs {
-        build_lib(compiled_libraries, target, *dep_lib);
-    }
     let repo = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
     env::set_current_dir(repo).unwrap();
 


### PR DESCRIPTION
Note that the order we build the libraries in, affects the order they are linked in.
To support single-pass linkers liked BFD, or gnu gold linker (`ld`) the libraries must be specified in the correct order on the final link line, and we can control that by modifying the order they are built in. (`cc-rs` prints instructions telling cargo to link the native static library we built)